### PR TITLE
Fix profile tab level progress to use exp

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -33,14 +33,15 @@ const Profile = () => {
   const { progressStats, loading: progressLoading } = useProgressTracking();
   const { checkDailyProgress } = useNotifications();
   const { profile, userExp, loading: profileLoading } = useProfile();
+  const { stats: unifiedStats, getLevelInfo } = useUnifiedStats();
   const { userAchievements, getAchievementProgress } = useAchievements();
-  const { stats: unifiedStats } = useUnifiedStats();
   const [activeTab, setActiveTab] = useState("overview");
   const [showAddHabit, setShowAddHabit] = useState(false);
   const [newHabit, setNewHabit] = useState({ name: "", description: "", color: "bg-blue-500", goal: "daily" as const });
 
   const stats = getHabitStats();
   const achievementProgress = getAchievementProgress(stats);
+  const levelInfo = getLevelInfo();
 
   const handleAddHabit = async () => {
     if (!newHabit.name.trim()) return;
@@ -84,7 +85,7 @@ const Profile = () => {
                 {profile?.display_name || profile?.email?.split('@')[0] || 'User'}
               </h2>
               <p className="text-muted-foreground">
-                Level {unifiedStats?.current_level || 0} • {unifiedStats?.lunar_crystals || 0} Crystals
+                Level {levelInfo.level || 0} • {unifiedStats?.lunar_crystals || 0} Crystals
               </p>
               <p className="text-xs text-muted-foreground">{profile?.email}</p>
             </div>
@@ -98,13 +99,13 @@ const Profile = () => {
           {/* XP Progress */}
           <div className="space-y-2">
             <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Progress to Level {(unifiedStats?.current_level || 0) + 1}</span>
+              <span className="text-muted-foreground">Progress to Level {(levelInfo.level || 0) + 1}</span>
               <span className="text-primary font-medium">
-                {unifiedStats?.total_exp || 0} / {((unifiedStats?.current_level || 0) + 1) * 100} XP
+                {(unifiedStats?.total_exp || 0)} / {levelInfo.nextLevelPoints} XP
               </span>
             </div>
             <Progress 
-              value={((unifiedStats?.total_exp || 0) % 100)} 
+              value={(levelInfo.progress || 0) * 100} 
               className="h-3 animate-streakGlow" 
             />
           </div>
@@ -140,7 +141,7 @@ const Profile = () => {
         <div className="grid grid-cols-3 gap-3">
           <Card className="card-elegant p-4 text-center hover-glow animate-slideInUp" style={{ animationDelay: '0.4s' }}>
             <Trophy className="w-6 h-6 text-primary mx-auto mb-2" />
-            <p className="text-lg font-bold text-foreground">{unifiedStats?.current_level || 0}</p>
+            <p className="text-lg font-bold text-foreground">{levelInfo.level || 0}</p>
             <p className="text-xs text-muted-foreground">Level</p>
           </Card>
           


### PR DESCRIPTION
Link profile tab level progress to user EXP and fix `useAchievements` destructuring.

The previous implementation of the profile tab's level and progress bar incorrectly used lunar crystals or a fixed 100 XP per level. This PR updates it to accurately reflect user experience points by leveraging `useUnifiedStats.getLevelInfo()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-97937264-8a2c-4480-a990-0c74b0e4826e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97937264-8a2c-4480-a990-0c74b0e4826e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

