### PR TITLE
Confirm stats reset with data download and crystal option

### DIFF
--- a/src/hooks/useResetStats.ts
+++ b/src/hooks/useResetStats.ts
@@ -8,7 +8,7 @@ export const useResetStats = () => {
   const { user } = useAuth();
   const { toast } = useToast();
 
-  const resetStats = async () => {
+  const resetStats = async (resetCrystals: boolean = true) => {
     if (!user) {
       toast({
         title: "Error",
@@ -21,7 +21,8 @@ export const useResetStats = () => {
     setIsResetting(true);
     try {
       const { error } = await supabase.rpc('reset_user_stats', {
-        p_user_id: user.id
+        p_user_id: user.id,
+        p_reset_crystals: resetCrystals
       });
 
       if (error) throw error;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -28,6 +28,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { useResetStats } from '@/hooks/useResetStats';
 import { LunarCrystalLogo } from '@/components/LunarCrystalLogo';
 import { useToast } from '@/hooks/use-toast';
+import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogFooter, AlertDialogTitle, AlertDialogDescription, AlertDialogCancel, AlertDialogAction } from '@/components/ui/alert-dialog';
+import { Checkbox } from '@/components/ui/checkbox';
 
 const Settings = () => {
   const { 
@@ -69,6 +71,7 @@ const Settings = () => {
     email: user?.email || 'user@example.com',
     avatar: user?.user_metadata?.avatar_url || '',
   });
+  const [resetCrystals, setResetCrystals] = useState(true);
 
   const handleExportData = () => {
     try {
@@ -492,15 +495,55 @@ ${[
                 </div>
                 
                 <div className="pt-4 border-t">
-                  <Button 
-                    onClick={resetStats}
-                    disabled={isResetting}
-                    variant="destructive" 
-                    className="w-full mb-3"
-                  >
-                    <RefreshCw className={`w-4 h-4 mr-2 ${isResetting ? 'animate-spin' : ''}`} />
-                    {isResetting ? 'Resetting...' : 'Reset All Stats'}
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button 
+                        disabled={isResetting}
+                        variant="destructive" 
+                        className="w-full mb-3"
+                      >
+                        <RefreshCw className={`w-4 h-4 mr-2 ${isResetting ? 'animate-spin' : ''}`} />
+                        {isResetting ? 'Resetting...' : 'Reset All Stats'}
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Reset all stats?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This action will permanently reset your progress, habits, EXP, levels, and history. Do you want to continue?
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <div className="space-y-4 py-2">
+                        <div className="flex items-center justify-between p-3 rounded-md border">
+                          <div>
+                            <p className="font-medium text-foreground">Download your data</p>
+                            <p className="text-sm text-muted-foreground">Export a full backup before resetting.</p>
+                          </div>
+                          <Button onClick={handleExportData} variant="outline">
+                            <Download className="w-4 h-4 mr-2" />
+                            Export
+                          </Button>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <Checkbox 
+                            id="reset-crystals"
+                            checked={resetCrystals}
+                            onCheckedChange={(v) => setResetCrystals(Boolean(v))}
+                          />
+                          <Label htmlFor="reset-crystals">Also reset Lunar Crystals to 0</Label>
+                        </div>
+                      </div>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction 
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          onClick={() => resetStats(resetCrystals)}
+                        >
+                          Reset Now
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                   
                   <Button 
                     onClick={handleSignOut}

--- a/supabase/migrations/20250824090000_add_reset_crystals_flag.sql
+++ b/supabase/migrations/20250824090000_add_reset_crystals_flag.sql
@@ -1,0 +1,70 @@
+-- Add optional flag to control lunar crystal reset during stats reset
+-- Drops old single-arg function and creates a new two-arg version
+
+DROP FUNCTION IF EXISTS public.reset_user_stats(uuid) CASCADE;
+
+CREATE OR REPLACE FUNCTION public.reset_user_stats(
+  p_user_id uuid,
+  p_reset_crystals boolean DEFAULT true
+)
+RETURNS VOID 
+LANGUAGE plpgsql 
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid uuid;
+BEGIN
+  -- Security check: ensure user can only reset their own stats
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF v_uid <> p_user_id THEN
+    RAISE EXCEPTION 'Forbidden: can only reset your own stats';
+  END IF;
+
+  -- Reset user experience with optional lunar crystal reset
+  UPDATE public.user_experience 
+  SET total_exp = 0,
+      current_level = 0,
+      lunar_crystals = CASE WHEN p_reset_crystals THEN 0 ELSE lunar_crystals END,
+      updated_at = now()
+  WHERE user_id = p_user_id;
+  
+  -- Clear habit completions
+  DELETE FROM public.habit_completions WHERE user_id = p_user_id;
+  
+  -- Clear EXP transactions
+  DELETE FROM public.exp_transactions WHERE user_id = p_user_id;
+  
+  -- Clear level history
+  DELETE FROM public.level_history WHERE user_id = p_user_id;
+  
+  -- Clear reward purchases
+  DELETE FROM public.reward_purchases WHERE user_id = p_user_id;
+  
+  -- Clear user achievements
+  DELETE FROM public.user_achievements WHERE user_id = p_user_id;
+  
+  -- Reset all habits completion status
+  UPDATE public.habits 
+  SET updated_at = now() 
+  WHERE user_id = p_user_id;
+  
+  -- Add reset notification
+  INSERT INTO public.notifications (user_id, title, message, type)
+  VALUES (
+    p_user_id,
+    'Stats Reset',
+    CASE WHEN p_reset_crystals THEN 'All your stats and crystals have been reset to zero.'
+         ELSE 'All your stats have been reset to zero (crystals preserved).'
+    END,
+    'system'
+  );
+END;
+$$;
+
+-- Grant execute permissions only to authenticated users
+REVOKE ALL ON FUNCTION public.reset_user_stats(uuid, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.reset_user_stats(uuid, boolean) TO authenticated;


### PR DESCRIPTION
Add a confirmation dialog for "Reset All Stats" with a data export option and a checkbox to optionally preserve Lunar Crystals.

---
<a href="https://cursor.com/background-agent?bcId=bc-6781912e-feb4-4e7a-8f07-f9b8d3649683">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6781912e-feb4-4e7a-8f07-f9b8d3649683">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

