### PR TITLE
Update habit rewards and enable deletion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,13 +20,11 @@ import ExportData from "./pages/ExportData";
 import Auth from "./pages/Auth";
 import NotFound from "./pages/NotFound";
 
-import { useLunarCrystalIntegration } from "@/hooks/useLunarCrystalIntegration";
 import { useEXPIntegration } from "@/hooks/useEXPIntegration";
 
 const queryClient = new QueryClient();
 
 function App() {
-  useLunarCrystalIntegration();
   useEXPIntegration();
   
   return (

--- a/src/hooks/useEXPIntegration.ts
+++ b/src/hooks/useEXPIntegration.ts
@@ -1,34 +1,23 @@
 import { useEffect } from 'react';
-import { useEXPSystem } from './useEXPSystem';
-import { useLunarCrystals } from './useLunarCrystals';
+import { useUnifiedStats } from './useUnifiedStats';
 
 export const useEXPIntegration = () => {
-  const { addEXP } = useEXPSystem();
-  const { earnCrystals, settings } = useLunarCrystals();
+  const { addEXP } = useUnifiedStats();
 
   useEffect(() => {
     // Listen for habit completion events
-    const handleHabitCompleted = (event: CustomEvent) => {
-      const { habitId, streak, expGained = 100 } = event.detail;
-      
-      // Add EXP first
-      const leveledUp = addEXP(expGained, `Habit completion: ${habitId}`);
-      
-      // Then handle crystal earning (no longer automatic from habits)
-      // Users need to convert EXP to crystals manually in the Shop
-      
+    const handleHabitCompleted = async (event: CustomEvent) => {
+      const { habitId, expGained = 100 } = event.detail;
+      const leveledUp = await addEXP(expGained, `Habit completion: ${habitId}`);
       if (leveledUp) {
-        // Show level up notification or celebration
         console.log('Level up!');
       }
     };
 
     // Listen for task completion events
-    const handleTaskCompleted = (event: CustomEvent) => {
+    const handleTaskCompleted = async (event: CustomEvent) => {
       const { taskId, expGained = 50 } = event.detail;
-      
-      const leveledUp = addEXP(expGained, `Task completion: ${taskId}`);
-      
+      const leveledUp = await addEXP(expGained, `Task completion: ${taskId}`);
       if (leveledUp) {
         console.log('Level up!');
       }
@@ -43,7 +32,7 @@ export const useEXPIntegration = () => {
       window.removeEventListener('habitCompleted', handleHabitCompleted as EventListener);
       window.removeEventListener('taskCompleted', handleTaskCompleted as EventListener);
     };
-  }, [addEXP, earnCrystals, settings]);
+  }, [addEXP]);
 
   return null; // This hook only provides side effects
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,18 +4,18 @@ import { Progress } from "@/components/ui/progress";
 import { Trophy, Target, Flame, Star, BookOpen, Plus, TrendingUp, Calendar, Zap, Settings } from "lucide-react";
 import { useHabits } from "@/hooks/useHabits";
 import { useLunarCrystals } from "@/hooks/useLunarCrystals";
-import { useLunarCrystalIntegration } from "@/hooks/useLunarCrystalIntegration";
 import { LunarCrystalLogo } from "@/components/LunarCrystalLogo";
 import { Link } from "react-router-dom";
+import { useUnifiedStats } from "@/hooks/useUnifiedStats";
 
 const Home = () => {
   const { habits, completeHabit, getHabitStats } = useHabits();
-  const { crystals, getLevelInfo } = useLunarCrystals();
+  const { crystals } = useLunarCrystals();
+  const { stats: unifiedStats, getLevelInfo } = useUnifiedStats();
   const stats = getHabitStats();
   const levelInfo = getLevelInfo();
   
-  // Initialize lunar crystal integration
-  useLunarCrystalIntegration();
+
 
   return (
     <div className="min-h-screen bg-background pt-16 pb-20 safe-area-inset-top animate-slideInUp">
@@ -56,14 +56,14 @@ const Home = () => {
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs text-muted-foreground">Progress to next level</span>
             <span className="text-xs text-primary font-medium">
-              {crystals} / {levelInfo.nextLevelPoints}
+              {(unifiedStats?.total_exp || 0)} / {levelInfo.nextLevelPoints} XP
             </span>
           </div>
           <div className="w-full bg-muted rounded-full h-2">
             <div 
               className="bg-primary rounded-full h-2 transition-all duration-500 animate-streakGlow"
               style={{ 
-                width: `${Math.min(100, ((crystals - levelInfo.pointsRequired) / (levelInfo.nextLevelPoints - levelInfo.pointsRequired)) * 100)}%` 
+                width: `${Math.min(100, (levelInfo.progress || 0) * 100)}%` 
               }}
             />
           </div>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -299,7 +299,7 @@ const Profile = () => {
             )}
 
             {habits.map((habit) => (
-              <Card key={habit.id} className="card-interactive p-4 hover-glow animate-slideInUp" onClick={() => handleCompleteHabit(habit.id)}>
+              <Card key={habit.id} className="card-interactive p-4 hover-glow animate-slideInUp group" onClick={() => handleCompleteHabit(habit.id)}>
                 <div className="flex items-center gap-3 mb-3">
                   <div className={`w-3 h-3 rounded-full ${habit.color}`} />
                   <div className="flex-1">


### PR DESCRIPTION
Enable habit deletion and reconfigure habit/task completion to award EXP instead of lunar crystals for accurate progress bar updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef8b008d-fbd6-41cb-b001-5a567748a013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef8b008d-fbd6-41cb-b001-5a567748a013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

